### PR TITLE
Remove a backslash from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Commands to build
 
     git clone http://github.com/xenserver/win-xenguestagent
     cd win-xenguestagent
-    .\\build.py [checked | free]
+    .\build.py [checked | free]
 
 Runtime Dependencies
 --------------------


### PR DESCRIPTION
Github's markdown interpeter doesn't need it like Dingus does
