### PR TITLE
[CP-5322] Add a new feature to set guest hostname via the guest agent

### DIFF
--- a/src/xenguestagent/XenService.cs
+++ b/src/xenguestagent/XenService.cs
@@ -244,6 +244,8 @@ namespace xenwinsvc
                 new FeatureShutdown(this);
                 new FeaturePing(this);
                 new FeatureDomainJoin(this);
+                new FeatureSetComputerName(this);
+
                 wmisession.Log("About to try snapshot");
                 if (FeatureSnapshot.IsSnapshotSupported())
                 {

--- a/src/xenguestlib/Win32Impl.cs
+++ b/src/xenguestlib/Win32Impl.cs
@@ -63,7 +63,44 @@ namespace xenwinsvc
             return isWOW64();
         }
 
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+        static extern bool GetComputerNameEx(COMPUTER_NAME_FORMAT NameType,
+           [Out] StringBuilder lpBuffer, ref uint lpnSize);
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+        static public extern bool SetComputerNameEx(COMPUTER_NAME_FORMAT NameType,
+            string lpBuffer);
+        public enum COMPUTER_NAME_FORMAT
+        {
+            ComputerNameNetBIOS,
+            ComputerNameDnsHostname,
+            ComputerNameDnsDomain,
+            ComputerNameDnsFullyQualified,
+            ComputerNamePhysicalNetBIOS,
+            ComputerNamePhysicalDnsHostname,
+            ComputerNamePhysicalDnsDomain,
+            ComputerNamePhysicalDnsFullyQualified,
+        }
+        static public string GetComputerDnsHostname()
+        {
+            uint size=0;
+            StringBuilder hostname = null;
 
+            while (!GetComputerNameEx(COMPUTER_NAME_FORMAT.ComputerNamePhysicalDnsHostname, hostname, ref size))
+            {
+                int err = Marshal.GetLastWin32Error();
+                if ((err == ERROR_INSUFFICIENT_BUFFER) || (err == ERROR_MORE_DATA))
+                {
+                    size += 1;
+                    hostname = new StringBuilder((int)size);
+                }
+                else
+                {
+                    throw new Exception("Unable to get computer name : " + err.ToString());
+                }
+            }
+
+            return hostname.ToString();
+        }
 
 
         [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]


### PR DESCRIPTION
Feature is present if control/feature-setcomputername=1

To set the default name write 'set' to control/setcomputername/action

To set a non-default name write the name to control/setcomputername/name

The response appears in control/setcomputername/state

control/setcomputername/error may contain additional error information

control/setcomputername/state should be removed if you do not intend to
reboot the VM to initiate a name change

(note: this sets the DNS name, which may be up to 64 characters, the
NETBIOS name can only be up to 15 characters, and will be truncated
if the hostname exceeds this)

Signed-off-by: Ben Chalmers Ben.Chalmers@citrix.com
