### PR TITLE
[CP-5322] Add a new feature to set guest hostname via the guest agent

### DIFF
--- a/src/xenguestagent/XenService.cs
+++ b/src/xenguestagent/XenService.cs
@@ -244,6 +244,8 @@ namespace xenwinsvc
                 new FeatureShutdown(this);
                 new FeaturePing(this);
                 new FeatureDomainJoin(this);
+                new FeatureSetComputerName(this);
+
                 wmisession.Log("About to try snapshot");
                 if (FeatureSnapshot.IsSnapshotSupported())
                 {

--- a/src/xenguestlib/Features.cs
+++ b/src/xenguestlib/Features.cs
@@ -35,6 +35,7 @@ using System.Management;
 using System.Windows.Forms;
 using Microsoft.Win32;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace xenwinsvc
 {
@@ -241,6 +242,170 @@ namespace xenwinsvc
         }
     }
 
+    // To use SetComputername Feature
+    //
+    // (all keys are relative to /domain/local/xxx/control/setcomputername/)
+    //
+    // Take a transaction
+    // Check that feature-setcomputername exists else, drop transation
+    // if state is set, or action is set, drop transaction,
+    //   wait, then try again
+    // if you want to set a computer name other than the xapi name for the domain, 
+    //   set computername to the desited name (otherwise the xapi name for the
+    //   domain will be used as a default) 
+    // set action to "set"
+    // commit the transaction
+    // read the value of state, it should read either
+    //   InProgress
+    //   NoChange
+    //   SucceededNeedsReboot
+    //   Failed
+    // while state reads InProgress, wait and reread the value of state 
+    //   until it reads either Failed or Succeded
+    // once the action has completed, the action key will be removed
+    // in the event state reads Failed, error will contain some info
+    //   which may be usable
+    // in other cases, 
+    // if state reads NoChange, the VM was already set to the desired name
+    // if the state reads SucceededNeedsReboot, the rename succeded, and the
+    //   VM must be rebooted for the change to take effect
+    // you should remove the state entry if finished and not rebooting to allow
+    //   other applications the opportunity to change the computer name.
+
+    public class FeatureSetComputerName : Feature
+    {
+        XenStoreItem name;
+        XenStoreItem state;
+        XenStoreItem error;
+        XenStoreItem warn;
+
+        public FeatureSetComputerName(IExceptionHandler exceptionhandler)
+            : base("Set Computer Name", "control/feature-setcomputername", "control/setcomputername/action", true, exceptionhandler)
+        {
+            name =  wmisession.GetXenStoreItem("control/setcomputername/name");
+            state =  wmisession.GetXenStoreItem("control/setcomputername/state");
+            error = wmisession.GetXenStoreItem("control/setcomputername/error");
+            warn = wmisession.GetXenStoreItem("control/setcomputername/warn");
+        }
+        
+        void SetComputerName() {
+
+            wmisession.Log("Set Computer Name Requested");
+            state.value = "InProgress";
+            String defaultname;
+            bool res;
+
+            try {
+                defaultname = name.value;
+                name.Remove();
+            }
+            catch {
+                try {
+                    wmisession.Log("Setting computer name to default");
+                    XenStoreItem name = wmisession.GetXenStoreItem("name");
+                    defaultname = name.value;
+                    
+                }
+                catch (Exception e){
+                    wmisession.Log("Unable to read default name for domain from xenstore: "+ e.ToString());
+                    error.value = "Can't read default computer name";
+                    state.value = "Failed";
+                    return;
+                }
+            }
+
+            if (defaultname.Equals("")) {
+                wmisession.Log("Can't set to empty computer name");
+                error.value = "Computer name empty";
+                state.value = "Failed";
+                return;
+            }
+
+            if (defaultname.Length > Win32Impl.MAX_COMPUTERNAME_LENGTH)
+            {
+                warn.value = "Computer name exceeds MAX_COMPUTERNAME_LENGTH.  The NetBIOS name will be truncated";
+            }
+
+            try
+            {
+                wmisession.Log("Setting computer name to "+defaultname);
+                Win32Impl.SetLastError(0);
+                res = Win32Impl.SetComputerNameEx(Win32Impl.COMPUTER_NAME_FORMAT.ComputerNamePhysicalDnsHostname, defaultname);
+                if (!res) {
+                    wmisession.Log("Setting computer name failed " + Marshal.GetLastWin32Error().ToString());
+                    error.value = "Setting name failed (error code "+Marshal.GetLastWin32Error().ToString()+")";
+                    state.value = "Failed";
+                    return;
+                }
+                wmisession.Log("Setting computer name succceded");
+            }
+            catch(Exception e)
+            {
+                wmisession.Log("Exception setting computer name : " + e.ToString());
+                error.value = "Exception calling set computer name";
+                state.value = "Failed";
+                return;
+            }
+            try
+            {
+                wmisession.Log("Target hostname " + defaultname);
+                wmisession.Log("Current hostname" + Win32Impl.GetComputerDnsHostname());
+                if (defaultname.Equals(Win32Impl.GetComputerDnsHostname()))
+                {
+                    wmisession.Log("No need to reboot to change computer name, already " + defaultname);
+                    state.value = "NoChange";
+                    return;
+                }
+            }
+            catch{
+            }
+            state.value = "SucceededNeedsReboot";
+        }
+
+
+        override protected void onFeature()
+        {
+            if (controlKey.Exists() && !state.Exists()) {
+                try {
+                    if (error.Exists()) {
+                        error.Remove();
+                    }
+                    if (warn.Exists())
+                    {
+                        warn.Remove();
+                    }
+
+                    if (state.Exists())
+                    {
+                        error.value = "Setting name already in progress";
+                        state.value = "Failed";
+                        return;
+                    }
+                    if (controlKey.value.Equals("set")) {
+                        SetComputerName();
+                    }
+                    else {
+                        error.value = "Unknown action : " + controlKey.value;
+                        state.value = "Failed";
+                    }
+                }
+                catch (Exception e) {
+                    if (!error.Exists()) {
+                        error.value=e.ToString();
+                    }
+                    state.value="Failed";
+                }
+                finally {
+                    // We always want to remove the controlKey, so that
+                    // it can be set again
+                    controlKey.Remove();
+                }
+            }
+        }
+    }
+
+
+
     // To use DomainJoin Feature
     //
     // (all keys are relative to /domain/local/xxx/domainjoin/)
@@ -271,75 +436,91 @@ namespace xenwinsvc
         XenStoreItem password;
         XenStoreItem state;
         XenStoreItem error;
-        
-        public FeatureDomainJoin(IExceptionHandler exceptionhandler) : base("Domain Join", "", "control/domainjoin/action", true, exceptionhandler) {
-            domainName =  wmisession.GetXenStoreItem("control/domainjoin/domainname");
-            userName =  wmisession.GetXenStoreItem("control/domainjoin/user");
-            password =  wmisession.GetXenStoreItem("control/domainjoin/password");
-            state =  wmisession.GetXenStoreItem("control/domainjoin/state");
+
+        public FeatureDomainJoin(IExceptionHandler exceptionhandler)
+            : base("Domain Join", "", "control/domainjoin/action", true, exceptionhandler)
+        {
+            domainName = wmisession.GetXenStoreItem("control/domainjoin/domainname");
+            userName = wmisession.GetXenStoreItem("control/domainjoin/user");
+            password = wmisession.GetXenStoreItem("control/domainjoin/password");
+            state = wmisession.GetXenStoreItem("control/domainjoin/state");
             error = wmisession.GetXenStoreItem("control/domainjoin/error");
         }
 
-        void JoinDomain() {
+        void JoinDomain()
+        {
             state.value = "InProgress";
             ManagementObject cs = WmiBase.Singleton.Win32_ComputerSystem;
             ManagementBaseObject mb = cs.GetMethodParameters("JoinDomainOrWorkgroup");
             mb["Name"] = domainName.value;
             mb["Password"] = password.value;
-            mb["UserName"] = domainName.value+"\\"+userName.value;
+            mb["UserName"] = domainName.value + "\\" + userName.value;
             mb["AccountOU"] = null;
             mb["FJoinOptions"] = (UInt32)1;
             ManagementBaseObject outParam = cs.InvokeMethod("JoinDomainOrWorkgroup", mb, null);
-            if ((UInt32)outParam["returnValue"] == 0) {
-                state.value="Succeeded";
+            if ((UInt32)outParam["returnValue"] == 0)
+            {
+                state.value = "Succeeded";
             }
-            else {
-                error.value=""+(UInt32)outParam["returnValue"];
-                state.value="Failed";
+            else
+            {
+                error.value = "" + (UInt32)outParam["returnValue"];
+                state.value = "Failed";
             }
         }
 
-        void UnjoinDomain() {
-             state.value = "InProgress";
-             ManagementObject cs = WmiBase.Singleton.Win32_ComputerSystem;
-             ManagementBaseObject mb = cs.GetMethodParameters("UnjoinDomainOrWorkgroup");
-             mb["Password"] = password.value;
-             mb["UserName"] = domainName.value+"\\"+userName.value;
-             mb["FUnjoinOptions"] = (UInt32)0;
-             ManagementBaseObject outParam = cs.InvokeMethod("UnjoinDomainOrWorkgroup", mb, null);
-             if ((UInt32)outParam["returnValue"] == 0) {
-                 state.value="Succeeded";
-             }
-             else {
-                 error.value=""+(UInt32)outParam["returnValue"];
-                 state.value="Failed";
-             }
+        void UnjoinDomain()
+        {
+            state.value = "InProgress";
+            ManagementObject cs = WmiBase.Singleton.Win32_ComputerSystem;
+            ManagementBaseObject mb = cs.GetMethodParameters("UnjoinDomainOrWorkgroup");
+            mb["Password"] = password.value;
+            mb["UserName"] = domainName.value + "\\" + userName.value;
+            mb["FUnjoinOptions"] = (UInt32)0;
+            ManagementBaseObject outParam = cs.InvokeMethod("UnjoinDomainOrWorkgroup", mb, null);
+            if ((UInt32)outParam["returnValue"] == 0)
+            {
+                state.value = "Succeeded";
+            }
+            else
+            {
+                error.value = "" + (UInt32)outParam["returnValue"];
+                state.value = "Failed";
+            }
         }
 
 
         override protected void onFeature()
         {
-            if (controlKey.Exists() && !state.Exists()) {
-                try {
-                    if (error.Exists()) {
+            if (controlKey.Exists() && !state.Exists())
+            {
+                try
+                {
+                    if (error.Exists())
+                    {
                         error.Remove();
                     }
-                    if (!domainName.Exists()) {
+                    if (!domainName.Exists())
+                    {
                         error.value = "domainname must be specified";
                         throw new Exception("domainname must be specified");
                     }
-                    if (!userName.Exists()) {
+                    if (!userName.Exists())
+                    {
                         error.value = "username must be specified";
                         throw new Exception("username must be specified");
                     }
-                    if (!password.Exists()) {
+                    if (!password.Exists())
+                    {
                         error.value = "password must be specified";
                         throw new Exception("password must be specified");
                     }
-                    if (controlKey.value.Equals("joindomain")) {
+                    if (controlKey.value.Equals("joindomain"))
+                    {
                         JoinDomain();
                     }
-                    else if (controlKey.value.Equals("unjoindomain")) {
+                    else if (controlKey.value.Equals("unjoindomain"))
+                    {
                         UnjoinDomain();
                     }
                     // If completed, remove the arguments, to avoid
@@ -348,13 +529,16 @@ namespace xenwinsvc
                     userName.Remove();
                     password.Remove();
                 }
-                catch (Exception e) {
-                    if (!error.Exists()) {
-                        error.value=e.ToString();
+                catch (Exception e)
+                {
+                    if (!error.Exists())
+                    {
+                        error.value = e.ToString();
                     }
-                    state.value="Failed";
+                    state.value = "Failed";
                 }
-                finally {
+                finally
+                {
                     // We always want to remove the controlKey, so that
                     // it can be set again
                     controlKey.Remove();
@@ -362,7 +546,6 @@ namespace xenwinsvc
             }
         }
     }
-
     public class FeatureTerminalServicesReset : Feature {
         XenStoreItem datats;
         public FeatureTerminalServicesReset(IExceptionHandler exceptionhandler)

--- a/src/xenguestlib/PVInstallation.cs
+++ b/src/xenguestlib/PVInstallation.cs
@@ -41,6 +41,7 @@ namespace xenwinsvc
     {
         XenStoreItem osname;
         XenStoreItem hostname;
+        XenStoreItem hostnamedns;
         XenStoreItem domain;
 
 
@@ -225,6 +226,7 @@ namespace xenwinsvc
 
             osname = wmisession.GetXenStoreItem("data/os_name");
             hostname = wmisession.GetXenStoreItem("data/host_name");
+            hostnamedns = wmisession.GetXenStoreItem("data/host_name_dns");
             domain = wmisession.GetXenStoreItem("data/domain");
 
             oslicense = wmisession.GetXenStoreItem("attr/os/license");
@@ -377,6 +379,7 @@ namespace xenwinsvc
         {
             osname.value = (string)WmiBase.Singleton.Win32_OperatingSystem["Name"];
             hostname.value = (string)WmiBase.Singleton.Win32_ComputerSystem["Name"];
+            hostnamedns.value = Win32Impl.GetComputerDnsHostname();
             domain.value = (string)WmiBase.Singleton.Win32_ComputerSystem["Domain"];
         }
 

--- a/src/xenguestlib/Win32Impl.cs
+++ b/src/xenguestlib/Win32Impl.cs
@@ -63,8 +63,45 @@ namespace xenwinsvc
             return isWOW64();
         }
 
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+        static extern bool GetComputerNameEx(COMPUTER_NAME_FORMAT NameType,
+           [Out] StringBuilder lpBuffer, ref uint lpnSize);
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+        static public extern bool SetComputerNameEx(COMPUTER_NAME_FORMAT NameType,
+            string lpBuffer);
+        public enum COMPUTER_NAME_FORMAT
+        {
+            ComputerNameNetBIOS,
+            ComputerNameDnsHostname,
+            ComputerNameDnsDomain,
+            ComputerNameDnsFullyQualified,
+            ComputerNamePhysicalNetBIOS,
+            ComputerNamePhysicalDnsHostname,
+            ComputerNamePhysicalDnsDomain,
+            ComputerNamePhysicalDnsFullyQualified,
+        }
+        static public string GetComputerDnsHostname()
+        {
+            uint size=0;
+            StringBuilder hostname = null;
 
+            while (!GetComputerNameEx(COMPUTER_NAME_FORMAT.ComputerNamePhysicalDnsHostname, hostname, ref size))
+            {
+                int err = Marshal.GetLastWin32Error();
+                if ((err == ERROR_INSUFFICIENT_BUFFER) || (err == ERROR_MORE_DATA))
+                {
+                    size += 1;
+                    hostname = new StringBuilder((int)size);
+                }
+                else
+                {
+                    throw new Exception("Unable to get computer name : " + err.ToString());
+                }
+            }
 
+            return hostname.ToString();
+        }
+        public const int MAX_COMPUTERNAME_LENGTH = 15;
 
         [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]


### PR DESCRIPTION
Feature is present if control/feature-setcomputername=1

To set the default name write 'set' to control/setcomputername/action

To set a non-default name write the name to control/setcomputername/name

The response appears in control/setcomputername/state

control/setcomputername/warn may contain information about non-error
behaviours of this feature (eg, if the NetBIOS computer name will be
truncated)

control/setcomputername/error may contain additional error information

control/setcomputername/state should be removed if you do not intend to
reboot the VM to initiate a name change

(note: this sets the DNS name, which may be up to 64 characters, the
NETBIOS name can only be up to 15 characters, and will be truncated
if the hostname exceeds this)

This changeset also adds data/host_name_dns which will report the dns
hostname (as opposed to the NetBIOS hostname) of the computer

Signed-off-by: Ben Chalmers Ben.Chalmers@citrix.com
