### PR TITLE
CP-10490: puncture firewall when enabling RDP

### DIFF
--- a/src/xenguestlib/Features.cs
+++ b/src/xenguestlib/Features.cs
@@ -594,6 +594,7 @@ namespace xenwinsvc
                 ManagementObject termserv = WmiBase.Singleton.Win32_TerminalServiceSetting;
                 ManagementBaseObject mb = termserv.GetMethodParameters("SetAllowTSConnections");
                 mb["AllowTSConnections"] = (uint)(enable ? 1 : 0);
+                mb["ModifyFirewallException"] = 1;
                 termserv.InvokeMethod("SetAllowTSConnections", mb, null);
             }
             catch {


### PR DESCRIPTION
As request by enable RDP from XenCenter, guest agent need to add firewall exception for RDP service.
This code change is to add such exception in windows firewall settings.

Signed-off-by: Cheng Zhang cheng.zhang@citrix.com
