### PR TITLE
CP-10409: puncture firewall when enabling RDP in windows server 2003

### DIFF
--- a/proj/xenguestlib/xenguestlib.csproj
+++ b/proj/xenguestlib/xenguestlib.csproj
@@ -55,6 +55,17 @@
     <Compile Include="..\..\src\xenguestlib\Wmi.cs" />
   </ItemGroup>
   <ItemGroup>
+    <COMReference Include="NetFwTypeLib">
+      <Guid>{58FBCF7C-E7A9-467C-80B3-FC65E8FCCA08}</Guid>
+      <VersionMajor>1</VersionMajor>
+      <VersionMinor>0</VersionMinor>
+      <Lcid>0</Lcid>
+      <WrapperTool>tlbimp</WrapperTool>
+      <Isolated>False</Isolated>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </COMReference>
+  </ItemGroup>
+  <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
Because windows server 2003 cannot use parameter "ModifyFirewallException", using INetFwMgr to solve the firewall puncture.

Signed-off-by: Cheng Zhang <cheng.zhang@citrix.com>