### PR TITLE
CP-10953: Windows guest agent: announce feature-ts2=1

### DIFF
--- a/src/xenguestlib/Features.cs
+++ b/src/xenguestlib/Features.cs
@@ -549,7 +549,7 @@ namespace xenwinsvc
     public class FeatureTerminalServicesReset : Feature {
         XenStoreItem datats;
         public FeatureTerminalServicesReset(IExceptionHandler exceptionhandler)
-            : base("Terminal Services Reset", "", "data/ts", false, exceptionhandler)
+            : base("Terminal Services Reset", "control/feature-ts2", "data/ts", false, exceptionhandler)
         {
             datats = wmisession.GetXenStoreItem("data/ts");
             Disposer.Add(WmiBase.Singleton.ListenForEvent("__InstanceModificationEvent", new EventArrivedEventHandler(onFeatureWrapper)));


### PR DESCRIPTION
Use feature-ts2 so XenCenter or Xapi can know if they can enable RDP by using current PV tool or not.

Signed-off-by: Cheng Zhang <cheng.zhang@citrix.com>