### PR TITLE
CP-11966 : Execute batch scripts via xenstore interface

### DIFF
--- a/src/xenguestagent/XenService.cs
+++ b/src/xenguestagent/XenService.cs
@@ -220,6 +220,7 @@ namespace xenwinsvc
                 new FeaturePing(this);
                 new FeatureDomainJoin(this);
                 new FeatureSetComputerName(this);
+                new FeatureXSBatchCommand(this);
 
                 wmisession.Log("About to try snapshot");
                 if (FeatureSnapshot.IsSnapshotSupported())

--- a/src/xenguestlib/PVInstallation.cs
+++ b/src/xenguestlib/PVInstallation.cs
@@ -35,6 +35,8 @@ using System.Management;
 using System.Windows.Forms;
 using Microsoft.Win32;
 using System.Diagnostics;
+using System.IO;
+using System.IO.Pipes;
 namespace xenwinsvc
 {
     public class PVInstallation : Feature, IRefresh


### PR DESCRIPTION
Implements feature-xs-batcmd which allows for the execution of
batch files < 1024 characters long via a xenstore interface.

This is a temporary solution and should not be relied on.  Rather
XAPI interfaces which may or may not use this interface are the
correct way to execute commands on guests from Dom 0

Signed-off-by: Ben Chalmers <Ben.Chalmers@citrix.com>