### PR TITLE
CP-12665 : Add per-guest vm registry entry to prevent remote execution

### DIFF
--- a/src/xenguestlib/Features.cs
+++ b/src/xenguestlib/Features.cs
@@ -833,6 +833,13 @@ namespace xenwinsvc
                     }
                 }
 
+                if ((int)Registry.GetValue("HKEY_LOCAL_MACHINE\\Software\\Citrix\\Xentools", "NoRemoteExecution", 0)!=0) {
+                    this.stderr.value = "VM Blocked Remote Execution By Registry Key";
+                    result = FeatureXSBatchCommand.FAILURE;
+                    state.value = result;
+                    return;
+                }
+
                 runCommand(batchFile);
 
                 this.ret.value = returnCode.ToString();


### PR DESCRIPTION
To prevent remote execution on a particular guest via the BATCMD feature, set

DWORD : HKLM\SOFTWARE_Citrix\Xentools NoRemoteExecution to
anything other then 0