### PR TITLE
CA-217823 : Only respond to the console changing when the session whi…

### DIFF
--- a/src/xenguestagent/XenService.cs
+++ b/src/xenguestagent/XenService.cs
@@ -444,7 +444,7 @@ namespace xenwinsvc
                 lock (servicestatelock) { 
                     if (running)
                     {
-                        clipboardhandler.HandleSessionChange(changeDescription.Reason);
+                        clipboardhandler.HandleSessionChange(changeDescription.Reason, (uint)changeDescription.SessionId);
                     }
                 }
                 base.OnSessionChange(changeDescription);

--- a/src/xenguestlib/Clipboard.cs
+++ b/src/xenguestlib/Clipboard.cs
@@ -475,7 +475,6 @@ namespace xenwinsvc
             void restartWorker()
             {
                 wmisession.Log("Restart worker");
-
                 workerProcess.Stop(false);
                 workerProcess = null;
 
@@ -604,7 +603,7 @@ namespace xenwinsvc
                 try
                 {
                     if ((reason == System.ServiceProcess.SessionChangeReason.ConsoleConnect) || 
-                        (reason == System.ServiceProcess.SessionChangeReason.SessionLogon)) 
+                        (reason == System.ServiceProcess.SessionChangeReason.SessionLogon))
                     {
                         handleConsoleChanged();
                     }
@@ -664,9 +663,10 @@ namespace xenwinsvc
 
         }
 
-        public void HandleSessionChange(System.ServiceProcess.SessionChangeReason changeargs) {
+        public void HandleSessionChange(System.ServiceProcess.SessionChangeReason changeargs, uint sessionId) {
             lock (statelock) {
-                if (running) {
+                if (running && 
+                    (sessionId==Win32Impl.WTSGetActiveConsoleSessionId())) {
                     state.HandleConsoleChanged(changeargs);
                 }
             }


### PR DESCRIPTION
…ch changes is the console


Previously session changes (especially under Terminal Services versions of Windows) were causing additional xendprivs to be (re)spawned on the console session.