### PR TITLE
CA-239854 : Remove the need to access hal.dll

### DIFF
--- a/src/xenguestlib/PVInstallation.cs
+++ b/src/xenguestlib/PVInstallation.cs
@@ -233,7 +233,6 @@ namespace xenwinsvc
 
             osboottype = wmisession.GetXenStoreItem("attr/os/boottype");
             ossystem32 = wmisession.GetXenStoreItem("attr/os/system32_dir");
-            oshal = wmisession.GetXenStoreItem("attr/os/hal");
             osbootoptions = wmisession.GetXenStoreItem("attr/os_boot/options");
 
 
@@ -370,8 +369,6 @@ namespace xenwinsvc
             osboottype.value = System.Windows.Forms.SystemInformation.BootMode.ToString();
             ossystem32.value = Environment.GetFolderPath(Environment.SpecialFolder.System);
 
-            FileVersionInfo halinfo = FileVersionInfo.GetVersionInfo(Environment.GetFolderPath(Environment.SpecialFolder.System) + "\\hal.dll");
-            oshal.value = halinfo.InternalName;
             osbootoptions.value = (string)Registry.GetValue("HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control", "SystemStartOptions", "none");
             guestdotnetframework.value = System.Environment.Version.ToString();
             


### PR DESCRIPTION
We used to access hal.dll to find out precisely which shutdown
command to use.  We don't need that in 2k8r2 and above.

We have, however, continued to acces hal.dll to output the version
in xenstore /os/attr/hal

There is no good reason to do this - and I can't believe anyone
uses it.  So I'm going to remove this and see if anyone complains.

(We have, on odd situations,r un into problems accessing hal.dll
they are rare - but better to remove a moving part that doesn't
need to move, than to let it bite us somewhere down the road)