### PR TITLE
CA-264903 : All messages for the console dll are bounded by 0x02,0x03

### DIFF
--- a/src/XenConsoleComm/NamedPipeClientStreamWrapper.cs
+++ b/src/XenConsoleComm/NamedPipeClientStreamWrapper.cs
@@ -2,12 +2,18 @@
 using System.IO.Pipes;
 using System.Text;
 using XenConsoleComm.Interfaces;
+using System.Threading;
+using System.Linq;
+using System.IO;
+using System.Diagnostics;
 
 namespace XenConsoleComm.Wrappers
 {
+    public delegate void connectFn();
+
     internal class NamedPipeClientStreamWrapper : INamedPipeClientStream
     {
-        private NamedPipeClientStream _pipeStream;
+        private PipeStream _pipeStream;
         private static readonly UTF8Encoding UTF8Enc = new UTF8Encoding(false);
 
         // A 0-length UTF8 string may still occupy some bytes
@@ -34,30 +40,191 @@ namespace XenConsoleComm.Wrappers
             _pipeStream = namedPipeClientStream;
         }
 
+        
+        connectFn _connectFn = null;
         public NamedPipeClientStreamWrapper(
             string serverName,
             string pipeName,
             PipeDirection direction,
             PipeOptions options)
         {
-            _pipeStream = new NamedPipeClientStream(
+            NamedPipeClientStream pipe = new NamedPipeClientStream(
                 serverName,
                 pipeName,
                 direction,
                 options
             );
+            _connectFn = pipe.Connect;
+            _pipeStream = pipe;
         }
+
+        public NamedPipeClientStreamWrapper(
+            PipeStream wrappedPipeStream,
+            connectFn connectCallback = null)
+        {
+            _pipeStream = wrappedPipeStream;
+            _connectFn = connectCallback;
+        }
+
 
         public void Connect()
         {
-            _pipeStream.Connect();
-            _pipeStream.ReadMode = PipeTransmissionMode.Message;
+            if (_pipeStream.IsConnected)
+            {
+                throw new InvalidOperationException("The client is already connected.");
+            }
+            if (_connectFn != null) {
+                _connectFn();
+                _pipeStream.ReadMode = PipeTransmissionMode.Message;
+            }
+            
         }
 
         public void Dispose()
         {
             _pipeStream.Dispose();
         }
+
+        bool MessageNotStarted(int bytes)
+        {
+            int start = 0;
+
+            start = Array.IndexOf<byte>(readBuffer, 0x02,0,bytes);
+            if (start != -1)
+            {
+                return (MessageInProgress(start + 1, bytes - (start + 1)));
+            }
+
+            ReadMore(userByteCount);
+            return false;
+        }
+
+        bool MessageInProgress(int readOffset, int bytes)
+        {
+            status = messagestatus.INPROGRESS;
+
+            int end = Array.IndexOf<byte>(readBuffer, 0x03,readOffset, bytes);
+
+            if (end == -1) {
+                Array.Copy(readBuffer, readOffset, userBuffer, userOffset, bytes);
+                userOffset += bytes;
+                if (userOffset == userBuffer.GetLength(0)) {
+                    IndicateIncompleteMessage(userByteCount);
+                    return true;
+                }
+                else 
+                {
+                    return ReadMore(userByteCount-userOffset);
+                }
+            }
+            else {
+                end = end - readOffset;
+                Array.Copy(readBuffer, readOffset, userBuffer, userOffset, end);
+                Debug.Assert(cacheByteCount == 0);
+                cacheByteCount = bytes - end;
+                Array.Resize<byte>(ref cache, cacheByteCount);
+                Array.Copy(readBuffer, readOffset + end + 1, cache, 0, cacheByteCount);
+                end = end + userOffset;
+                userOffset = 0;
+                IndicateCompleteMessage(end);
+                return true;
+            }
+
+        }
+
+        void IndicateCompleteMessage(int bytesRead)
+        {
+            _isMessageComplete = true;
+            asyncMessage.Indicate(bytesRead, true);
+        }
+
+        void IndicateIncompleteMessage(int bytesRead)
+        {
+            _isMessageComplete = false;
+            asyncMessage.Indicate(bytesRead, false);
+        }
+
+        enum messagestatus
+        {
+            NOTSTARTED,
+            INPROGRESS
+        };
+        class WrapperAsyncMessageResult : IAsyncResult
+        {
+            bool _IsCompleted;
+            bool _CompletedSynchronously;
+            int _bytesRead;
+            EventWaitHandle _AsyncWaitHandle;
+            AsyncCallback _callback;
+            public void Indicate(int bytesRead, bool completed)
+            {
+                _IsCompleted = completed;
+                _bytesRead = bytesRead;
+                _AsyncWaitHandle.Set();
+                _callback(this);
+            }
+            public int bytesRead {
+                get { return _bytesRead; }
+            }
+            public WrapperAsyncMessageResult(IAsyncResult result, AsyncCallback callback)
+            {
+                _IsCompleted = result.IsCompleted;
+                _CompletedSynchronously = result.CompletedSynchronously;
+                _AsyncWaitHandle = new EventWaitHandle(result.IsCompleted, EventResetMode.ManualReset);
+                _callback = callback;
+            }
+            public WrapperAsyncMessageResult(bool synchronously, AsyncCallback callback)
+            {
+                if (synchronously)
+                {
+                    _CompletedSynchronously = true;
+                    _IsCompleted = true;
+                }
+                else
+                {
+                    _CompletedSynchronously = false;
+                    _IsCompleted = false;
+                }
+                _AsyncWaitHandle = new EventWaitHandle(_IsCompleted, EventResetMode.ManualReset);
+                _callback = callback;
+            }
+            public object AsyncState { get { return null; } }
+            public WaitHandle AsyncWaitHandle { get { return _AsyncWaitHandle; } }
+            public bool CompletedSynchronously { get { return _CompletedSynchronously; } }
+            public bool IsCompleted { get { return _IsCompleted; } }
+        };
+
+        messagestatus status = messagestatus.NOTSTARTED;
+
+        internal void OnBytesRead(IAsyncResult ar)
+        {
+            int bytesread = _pipeStream.EndRead(ar);
+            if (bytesread == 0)
+            {
+                IndicateIncompleteMessage(userOffset);
+                return;
+            }
+            if (status == messagestatus.NOTSTARTED) {
+                MessageNotStarted(bytesread);
+                return;
+            }
+            else if (status == messagestatus.INPROGRESS) {
+                MessageInProgress(0, bytesread);
+                return;
+            }
+            
+        }
+
+        byte[] readBuffer;
+        AsyncCallback callback;
+        int userOffset;
+        int userByteCount;
+        byte[] userBuffer;
+        object state;
+        byte[] cache = new byte[0];
+        int cacheByteCount = 0;
+        bool _isMessageComplete;
+        WrapperAsyncMessageResult asyncMessage;
 
         public IAsyncResult BeginRead(
             byte[] buffer,
@@ -66,16 +233,52 @@ namespace XenConsoleComm.Wrappers
             AsyncCallback callback,
             object state)
         {
-            return _pipeStream.BeginRead(buffer, offset, count, callback, state);
+            this._isMessageComplete = false;
+            this.status = messagestatus.NOTSTARTED;
+            this.readBuffer = new byte[count];
+            this.callback = callback;
+            this.userOffset = offset;
+            this.userByteCount = count;
+            this.userBuffer = buffer;
+            this.state = state;
+            if (cacheByteCount > 0)
+            {
+                int cacheCopy = Math.Min(cacheByteCount, count);
+                Array.Copy(cache, readBuffer, cacheCopy);
+                cacheByteCount = cacheByteCount - cacheCopy;
+                asyncMessage = new WrapperAsyncMessageResult(MessageNotStarted(cacheCopy), callback);
+                return asyncMessage;
+            }
+            else
+            {
+                asyncMessage = new WrapperAsyncMessageResult(_pipeStream.BeginRead(readBuffer, 0, count, OnBytesRead, state),callback);
+                return asyncMessage;
+            }
+        }
+
+        private bool ReadMore(int bytesToRead) {
+            if (cacheByteCount > 0)
+            {
+                int cacheCopy = Math.Min(cacheByteCount, bytesToRead);
+                Array.Copy(cache, readBuffer, cacheCopy);
+                cacheByteCount = cacheByteCount - cacheCopy;
+                return MessageNotStarted(cacheCopy);
+            }
+            else
+            {
+                _pipeStream.BeginRead(readBuffer, 0, bytesToRead, OnBytesRead, state);
+                return false;
+            }
         }
 
         public int EndRead(IAsyncResult asyncResult)
         {
-            return _pipeStream.EndRead(asyncResult);
+            return ((WrapperAsyncMessageResult)asyncResult).bytesRead;
         }
 
         public void Write(string value)
         {
+            value = '\x02'+value+'\x03'; //It's a message, so wrap it accordingly
             byte[] buffer = new byte[2 * WriteBufferSize];
 
             int charsLeft = value.Length;
@@ -129,7 +332,7 @@ namespace XenConsoleComm.Wrappers
 
         public bool IsMessageComplete
         {
-            get { return _pipeStream.IsMessageComplete; }
+            get { return _isMessageComplete; }
         }
 
         public bool IsConnected

--- a/src/XenConsoleComm/XenConsoleMessageEventArgs.cs
+++ b/src/XenConsoleComm/XenConsoleMessageEventArgs.cs
@@ -1,6 +1,7 @@
 ﻿using IXenConsoleComm;
 using System;
 using XenConsoleComm.Interfaces;
+using System.IO.Pipes;
 
 namespace XenConsoleComm
 {

--- a/src/XenConsoleComm/XenConsoleMessageEventArgs.cs
+++ b/src/XenConsoleComm/XenConsoleMessageEventArgs.cs
@@ -1,7 +1,6 @@
 ﻿using IXenConsoleComm;
 using System;
 using XenConsoleComm.Interfaces;
-using System.IO.Pipes;
 
 namespace XenConsoleComm
 {

--- a/src/XenConsoleComm/XenConsoleStream.cs
+++ b/src/XenConsoleComm/XenConsoleStream.cs
@@ -26,10 +26,11 @@ namespace XenConsoleComm
                 PipeOptions.Asynchronous
             )) { }
 
-        public XenConsoleStream(PipeStream pipeClient, connectFn connectFunction = null) :this (new NamedPipeClientStreamWrapper(pipeClient, connectFunction))
-        {
-        }
-
+        internal XenConsoleStream(PipeStream pipeClient, connectFn connectFunction = null) : this (
+            new NamedPipeClientStreamWrapper(
+                pipeClient, 
+                connectFunction
+            )) { }
 
         internal XenConsoleStream(INamedPipeClientStream pipeClient)
         {

--- a/src/XenConsoleComm/XenConsoleStream.cs
+++ b/src/XenConsoleComm/XenConsoleStream.cs
@@ -26,6 +26,11 @@ namespace XenConsoleComm
                 PipeOptions.Asynchronous
             )) { }
 
+        public XenConsoleStream(PipeStream pipeClient, connectFn connectFunction = null) :this (new NamedPipeClientStreamWrapper(pipeClient, connectFunction))
+        {
+        }
+
+
         internal XenConsoleStream(INamedPipeClientStream pipeClient)
         {
             _xenConsoleClient = pipeClient;

--- a/src/XenConsoleCommTests/AUserClass.cs
+++ b/src/XenConsoleCommTests/AUserClass.cs
@@ -1,5 +1,7 @@
 using IXenConsoleComm;
 using System;
+using System.Collections.Generic;
+using System.Text;
 
 namespace XenConsoleComm.Tests.Helpers
 {
@@ -9,9 +11,12 @@ namespace XenConsoleComm.Tests.Helpers
         private int _xcMessageHandlerCalled = 0;
         private int _disconnectHandlerCalled = 0;
 
+        public List<byte[]> readMessage;
+
         public AUserClass(IXenConsoleStream xcStream)
         {
             AttachToXenConsoleStream(xcStream);
+            readMessage = new List<byte[]>();
         }
 
         public AUserClass() { }
@@ -39,6 +44,8 @@ namespace XenConsoleComm.Tests.Helpers
         public void XenConsoleMessageEventHandler(object sender, EventArgs e)
         {
             ++_xcMessageHandlerCalled;
+            XenConsoleMessageEventArgs args = (XenConsoleMessageEventArgs)e;
+            readMessage.Add(UTF8Encoding.UTF8.GetBytes(args.Value));
         }
 
         public void XenConsoleDisconnectedEventHandler(object sender, EventArgs e)

--- a/src/XenConsoleCommTests/NamedPipeClientStreamStub.cs
+++ b/src/XenConsoleCommTests/NamedPipeClientStreamStub.cs
@@ -10,7 +10,7 @@ using XenConsoleComm.Tests.Helpers;
 
 namespace XenConsoleComm.Tests.Stubs
 {
-    internal class NamedPipeClientStreamStub: PipeStream
+    internal class NamedPipeClientStreamStub : PipeStream
     {
         private static readonly Random Rnd = new Random();
         public static readonly UTF8Encoding UTF8Enc = new UTF8Encoding(false);
@@ -115,9 +115,7 @@ namespace XenConsoleComm.Tests.Stubs
             }
         }
 
-        public override void Flush()
-        {
-        }
+        public override void Flush(){}
 
         private void ThreadWorker(string value, int count, byte[] buffer, AsyncCallback callback, AsyncResultStub ars)
         {
@@ -159,14 +157,8 @@ namespace XenConsoleComm.Tests.Stubs
 
         public override PipeTransmissionMode ReadMode
         {
-            get
-            {
-                return _readMode;
-            }
-            set
-            {
-                _readMode = value;
-            }
+            get { return _readMode; }
+            set { _readMode = value; }
         }
 
         new public bool IsMessageComplete
@@ -186,7 +178,7 @@ namespace XenConsoleComm.Tests.Stubs
             set { _pipeIsBroken = value; }
         }
 
-        override public bool CanRead
+        public override bool CanRead
         {
             get { return _canRead; }
         }

--- a/src/XenConsoleCommTests/NamedPipeClientStreamStub.cs
+++ b/src/XenConsoleCommTests/NamedPipeClientStreamStub.cs
@@ -31,7 +31,7 @@ namespace XenConsoleComm.Tests.Stubs
         private int _readsCompleted = 0;
         private Exception _callbackException = null;
 
-        public NamedPipeClientStreamStub() : base(PipeDirection.InOut,PipeTransmissionMode.Byte , 1024)
+        public NamedPipeClientStreamStub() : base(PipeDirection.InOut,PipeTransmissionMode.Byte , BufferSize)
         {
         }
 
@@ -43,7 +43,7 @@ namespace XenConsoleComm.Tests.Stubs
             IsConnected = true;
         }
 
-        override public IAsyncResult BeginRead(
+        public override IAsyncResult BeginRead(
             byte[] buffer,
             int offset,
             int count,
@@ -79,7 +79,7 @@ namespace XenConsoleComm.Tests.Stubs
             return ars;
         }
 
-        override public int EndRead(IAsyncResult asyncResult)
+        public override int EndRead(IAsyncResult asyncResult)
         {
             AsyncResultStub ars = (AsyncResultStub)asyncResult;
             // All keys of the hashmnap must have value '1' in the end.
@@ -93,25 +93,25 @@ namespace XenConsoleComm.Tests.Stubs
             Write(buffer, 0, buffer.Length);
         }
 
-        public override void Write(Byte[] buffer, Int32 offset, Int32 writecount)
+        public override void Write(Byte[] buffer, Int32 offset, Int32 count)
         {
             if (PipeIsBroken)
                 throw new IOException("Pipe is broken.");
 
-            int bytesLeft = writecount;
+            int bytesLeft = count;
             int index = offset;
 
             while (bytesLeft > 0)
             {
-                int count = bytesLeft < BufferSize
+                int writecount = bytesLeft < BufferSize
                     ? bytesLeft
                     : BufferSize;
 
                 byte[] chunk = new byte[BufferSize];
-                Array.Copy(buffer, index, chunk, 0, count);
+                Array.Copy(buffer, index, chunk, 0, writecount);
                 chunksWritten.Add(chunk);
-                bytesLeft -= count;
-                index += count;
+                bytesLeft -= writecount;
+                index += writecount;
             }
         }
 

--- a/src/XenConsoleCommTests/XenConsoleMessageEventArgsTests.cs
+++ b/src/XenConsoleCommTests/XenConsoleMessageEventArgsTests.cs
@@ -2,6 +2,7 @@
 using System;
 using System.IO;
 using XenConsoleComm.Tests.Stubs;
+using XenConsoleComm.Wrappers;
 
 namespace XenConsoleComm.Tests
 {
@@ -15,7 +16,7 @@ namespace XenConsoleComm.Tests
             NamedPipeClientStreamStub pipeStream = new NamedPipeClientStreamStub();
             XenConsoleMessageEventArgs message = new XenConsoleMessageEventArgs(
                 "test",
-                pipeStream
+                new NamedPipeClientStreamWrapper(pipeStream)
             );
 
             // Assert
@@ -32,7 +33,7 @@ namespace XenConsoleComm.Tests
             NamedPipeClientStreamStub pipeStream = new NamedPipeClientStreamStub();
             XenConsoleMessageEventArgs message = new XenConsoleMessageEventArgs(
                 "test",
-                pipeStream
+                new NamedPipeClientStreamWrapper(pipeStream)
             );
 
             // Assert
@@ -56,7 +57,7 @@ namespace XenConsoleComm.Tests
 
             XenConsoleMessageEventArgs message = new XenConsoleMessageEventArgs(
                 "test",
-                pipeStream
+                new NamedPipeClientStreamWrapper(pipeStream)
             );
 
             // Assert


### PR DESCRIPTION
The console DLL thinks in terms of messages
But xencons thinks in terms of bytes

This extends the NamedPipeClientStreamWrapper to make a translation
from bytes to messages.

This also converts the NamesPipeClientStreamStub into a PipeStream
which makes it easier to test as a drop in replacement for a
NamedPipeClientStream

Finally tests are added, and fixed put in place to make testing
work better in this new world.