### PR TITLE
CA-264903 : All messages for the console dll are bounded by 0x02,0x03

### DIFF
--- a/src/XenConsoleComm/NamedPipeClientStreamWrapper.cs
+++ b/src/XenConsoleComm/NamedPipeClientStreamWrapper.cs
@@ -1,13 +1,34 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO.Pipes;
 using System.Text;
+using System.Threading;
 using XenConsoleComm.Interfaces;
 
 namespace XenConsoleComm.Wrappers
 {
+    public delegate void connectFn();
+
     internal class NamedPipeClientStreamWrapper : INamedPipeClientStream
     {
-        private NamedPipeClientStream _pipeStream;
+
+        enum MessageStatus
+        {
+            NotStarted,
+            InProgress
+        };
+        private MessageStatus status = MessageStatus.NotStarted;
+        private byte[] readBuffer;
+        private AsyncCallback callback;
+        private int userOffset;
+        private int userByteCount;
+        byte[] userBuffer;
+        private object state;
+        private byte[] cache = new byte[0];
+        private int cacheByteCount = 0;
+        private bool _isMessageComplete;
+        private AsyncMessageResultWrapper asyncMessage;
+        private PipeStream _pipeStream;
         private static readonly UTF8Encoding UTF8Enc = new UTF8Encoding(false);
 
         // A 0-length UTF8 string may still occupy some bytes
@@ -34,29 +55,182 @@ namespace XenConsoleComm.Wrappers
             _pipeStream = namedPipeClientStream;
         }
 
+        
+        connectFn _connectFn = null;
         public NamedPipeClientStreamWrapper(
             string serverName,
             string pipeName,
             PipeDirection direction,
             PipeOptions options)
         {
-            _pipeStream = new NamedPipeClientStream(
+            NamedPipeClientStream pipe = new NamedPipeClientStream(
                 serverName,
                 pipeName,
                 direction,
                 options
             );
+            _connectFn = pipe.Connect;
+            _pipeStream = pipe;
         }
+
+        public NamedPipeClientStreamWrapper(
+            PipeStream wrappedPipeStream,
+            connectFn connectCallback = null)
+        {
+            _pipeStream = wrappedPipeStream;
+            _connectFn = connectCallback;
+        }
+
 
         public void Connect()
         {
-            _pipeStream.Connect();
-            _pipeStream.ReadMode = PipeTransmissionMode.Message;
+            if (_pipeStream.IsConnected)
+            {
+                throw new InvalidOperationException("The client is already connected.");
+            }
+            if (_connectFn != null) {
+                _connectFn();
+                _pipeStream.ReadMode = PipeTransmissionMode.Message;
+            }
+            
         }
 
         public void Dispose()
         {
             _pipeStream.Dispose();
+        }
+
+        private bool MessageNotStarted(int bytes)
+        {
+            int start = 0;
+
+            start = Array.IndexOf<byte>(readBuffer, 0x02, 0, bytes);
+            if (start != -1)
+            {
+                return (MessageInProgress(start + 1, bytes - (start + 1)));
+            }
+
+            ReadMore(userByteCount);
+            return false;
+        }
+
+        private bool MessageInProgress(int readOffset, int bytes)
+        {
+            status = MessageStatus.InProgress;
+
+            int end = Array.IndexOf<byte>(readBuffer, 0x03,readOffset, bytes);
+
+            if (end == -1) 
+            {
+                Array.Copy(readBuffer, readOffset, userBuffer, userOffset, bytes);
+                userOffset += bytes;
+                if (userOffset == userBuffer.GetLength(0)) 
+                {
+                    IndicateIncompleteMessage(userByteCount);
+                    return true;
+                }
+                else 
+                {
+                    return ReadMore(userByteCount-userOffset);
+                }
+            }
+            else 
+            {
+                end = end - readOffset;
+                Array.Copy(readBuffer, readOffset, userBuffer, userOffset, end);
+                Debug.Assert(cacheByteCount == 0);
+                cacheByteCount = bytes - end;
+                Array.Resize<byte>(ref cache, cacheByteCount);
+                Array.Copy(readBuffer, readOffset + end + 1, cache, 0, cacheByteCount);
+                end = end + userOffset;
+                userOffset = 0;
+                IndicateCompleteMessage(end);
+                return true;
+            }
+
+        }
+
+        private void IndicateCompleteMessage(int bytesRead)
+        {
+            _isMessageComplete = true;
+            asyncMessage.Indicate(bytesRead, true);
+        }
+
+        private void IndicateIncompleteMessage(int bytesRead)
+        {
+            _isMessageComplete = false;
+            asyncMessage.Indicate(bytesRead, false);
+        }
+
+        private class AsyncMessageResultWrapper : IAsyncResult
+        {
+            private bool _IsCompleted;
+            private bool _CompletedSynchronously;
+            private int _bytesRead;
+            private EventWaitHandle _AsyncWaitHandle;
+            private AsyncCallback _callback;
+ 
+
+            public void Indicate(int bytesRead, bool completed)
+            {
+                _IsCompleted = completed;
+                _bytesRead = bytesRead;
+                _AsyncWaitHandle.Set();
+                _callback(this);
+            }
+
+            public int BytesRead 
+            {
+                get { return _bytesRead; }
+            }
+
+            public AsyncMessageResultWrapper(IAsyncResult result, AsyncCallback callback)
+            {
+                _IsCompleted = result.IsCompleted;
+                _CompletedSynchronously = result.CompletedSynchronously;
+                _AsyncWaitHandle = new EventWaitHandle(result.IsCompleted, EventResetMode.ManualReset);
+                _callback = callback;
+            }
+
+            public AsyncMessageResultWrapper(bool synchronously, AsyncCallback callback)
+            {
+                if (synchronously)
+                {
+                    _CompletedSynchronously = true;
+                    _IsCompleted = true;
+                }
+                else
+                {
+                    _CompletedSynchronously = false;
+                    _IsCompleted = false;
+                }
+                _AsyncWaitHandle = new EventWaitHandle(_IsCompleted, EventResetMode.ManualReset);
+                _callback = callback;
+            }
+
+            public object AsyncState { get { return null; } }
+            public WaitHandle AsyncWaitHandle { get { return _AsyncWaitHandle; } }
+            public bool CompletedSynchronously { get { return _CompletedSynchronously; } }
+            public bool IsCompleted { get { return _IsCompleted; } }
+        };
+
+        private void OnBytesRead(IAsyncResult ar)
+        {
+            int bytesread = _pipeStream.EndRead(ar);
+            if (bytesread == 0)
+            {
+                IndicateIncompleteMessage(userOffset);
+                return;
+            }
+            if (status == MessageStatus.NotStarted) {
+                MessageNotStarted(bytesread);
+                return;
+            }
+            else if (status == MessageStatus.InProgress) {
+                MessageInProgress(0, bytesread);
+                return;
+            }
+            
         }
 
         public IAsyncResult BeginRead(
@@ -66,16 +240,53 @@ namespace XenConsoleComm.Wrappers
             AsyncCallback callback,
             object state)
         {
-            return _pipeStream.BeginRead(buffer, offset, count, callback, state);
+            this._isMessageComplete = false;
+            this.status = MessageStatus.NotStarted;
+            this.readBuffer = new byte[count];
+            this.callback = callback;
+            this.userOffset = offset;
+            this.userByteCount = count;
+            this.userBuffer = buffer;
+            this.state = state;
+            if (cacheByteCount > 0)
+            {
+                int cacheCopy = Math.Min(cacheByteCount, count);
+                Array.Copy(cache, readBuffer, cacheCopy);
+                cacheByteCount = cacheByteCount - cacheCopy;
+                asyncMessage = new AsyncMessageResultWrapper(MessageNotStarted(cacheCopy), callback);
+                return asyncMessage;
+            }
+            else
+            {
+                asyncMessage = new AsyncMessageResultWrapper(_pipeStream.BeginRead(readBuffer, 0, count, OnBytesRead, state),callback);
+                return asyncMessage;
+            }
+        }
+
+        private bool ReadMore(int bytesToRead) 
+        {
+            if (cacheByteCount > 0)
+            {
+                int cacheCopy = Math.Min(cacheByteCount, bytesToRead);
+                Array.Copy(cache, readBuffer, cacheCopy);
+                cacheByteCount = cacheByteCount - cacheCopy;
+                return MessageNotStarted(cacheCopy);
+            }
+            else
+            {
+                _pipeStream.BeginRead(readBuffer, 0, bytesToRead, OnBytesRead, state);
+                return false;
+            }
         }
 
         public int EndRead(IAsyncResult asyncResult)
         {
-            return _pipeStream.EndRead(asyncResult);
+            return ((AsyncMessageResultWrapper)asyncResult).BytesRead;
         }
 
         public void Write(string value)
         {
+            value = '\x02' + value + '\x03'; //It's a message, so wrap it accordingly
             byte[] buffer = new byte[2 * WriteBufferSize];
 
             int charsLeft = value.Length;
@@ -129,7 +340,7 @@ namespace XenConsoleComm.Wrappers
 
         public bool IsMessageComplete
         {
-            get { return _pipeStream.IsMessageComplete; }
+            get { return _isMessageComplete; }
         }
 
         public bool IsConnected

--- a/src/XenConsoleComm/XenConsoleStream.cs
+++ b/src/XenConsoleComm/XenConsoleStream.cs
@@ -26,6 +26,12 @@ namespace XenConsoleComm
                 PipeOptions.Asynchronous
             )) { }
 
+        internal XenConsoleStream(PipeStream pipeClient, connectFn connectFunction = null) : this (
+            new NamedPipeClientStreamWrapper(
+                pipeClient, 
+                connectFunction
+            )) { }
+
         internal XenConsoleStream(INamedPipeClientStream pipeClient)
         {
             _xenConsoleClient = pipeClient;

--- a/src/XenConsoleCommTests/AUserClass.cs
+++ b/src/XenConsoleCommTests/AUserClass.cs
@@ -1,5 +1,7 @@
 using IXenConsoleComm;
 using System;
+using System.Collections.Generic;
+using System.Text;
 
 namespace XenConsoleComm.Tests.Helpers
 {
@@ -9,9 +11,12 @@ namespace XenConsoleComm.Tests.Helpers
         private int _xcMessageHandlerCalled = 0;
         private int _disconnectHandlerCalled = 0;
 
+        public List<byte[]> readMessage;
+
         public AUserClass(IXenConsoleStream xcStream)
         {
             AttachToXenConsoleStream(xcStream);
+            readMessage = new List<byte[]>();
         }
 
         public AUserClass() { }
@@ -39,6 +44,8 @@ namespace XenConsoleComm.Tests.Helpers
         public void XenConsoleMessageEventHandler(object sender, EventArgs e)
         {
             ++_xcMessageHandlerCalled;
+            XenConsoleMessageEventArgs args = (XenConsoleMessageEventArgs)e;
+            readMessage.Add(UTF8Encoding.UTF8.GetBytes(args.Value));
         }
 
         public void XenConsoleDisconnectedEventHandler(object sender, EventArgs e)

--- a/src/XenConsoleCommTests/NamedPipeClientStreamStub.cs
+++ b/src/XenConsoleCommTests/NamedPipeClientStreamStub.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Pipes;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -9,7 +10,7 @@ using XenConsoleComm.Tests.Helpers;
 
 namespace XenConsoleComm.Tests.Stubs
 {
-    internal class NamedPipeClientStreamStub : INamedPipeClientStream
+    internal class NamedPipeClientStreamStub : PipeStream
     {
         private static readonly Random Rnd = new Random();
         public static readonly UTF8Encoding UTF8Enc = new UTF8Encoding(false);
@@ -23,7 +24,6 @@ namespace XenConsoleComm.Tests.Stubs
         private bool _pipeIsBroken = false;
         private bool _canRead = true;
         private bool _isMessageComplete = false;
-        private bool _isConnected = false;
         private bool _pipeServerIsReadWrite= true;
         private bool _invokeCallback = false;
 
@@ -31,19 +31,19 @@ namespace XenConsoleComm.Tests.Stubs
         private int _readsCompleted = 0;
         private Exception _callbackException = null;
 
+        public NamedPipeClientStreamStub() : base(PipeDirection.InOut,PipeTransmissionMode.Byte , BufferSize)
+        {
+        }
+
         public void Connect()
         {
-            if (IsConnected)
-                throw new InvalidOperationException("The client is already connected.");
             if (!PipeServerIsReadWrite)
                 throw new UnauthorizedAccessException("Access to the path is denied.");
 
             IsConnected = true;
         }
 
-        public void Dispose() { }
-
-        public IAsyncResult BeginRead(
+        public override IAsyncResult BeginRead(
             byte[] buffer,
             int offset,
             int count,
@@ -71,7 +71,7 @@ namespace XenConsoleComm.Tests.Stubs
             if (_readsReturn != null && _readsCompleted < _readsReturn.Length)
             {
                 Thread thread = new Thread(() =>
-                    ThreadWorker(_readsReturn[_readsCompleted], buffer, callback, ars)
+                    ThreadWorker(_readsReturn[_readsCompleted],count, buffer, callback, ars)
                 );
                 thread.Start();
             }
@@ -79,7 +79,7 @@ namespace XenConsoleComm.Tests.Stubs
             return ars;
         }
 
-        public int EndRead(IAsyncResult asyncResult)
+        public override int EndRead(IAsyncResult asyncResult)
         {
             AsyncResultStub ars = (AsyncResultStub)asyncResult;
             // All keys of the hashmnap must have value '1' in the end.
@@ -89,29 +89,35 @@ namespace XenConsoleComm.Tests.Stubs
 
         public void Write(string value)
         {
+            byte[] buffer = UTF8Enc.GetBytes(value);
+            Write(buffer, 0, buffer.Length);
+        }
+
+        public override void Write(Byte[] buffer, Int32 offset, Int32 count)
+        {
             if (PipeIsBroken)
                 throw new IOException("Pipe is broken.");
 
-            byte[] buffer = UTF8Enc.GetBytes(value);
-
-            int bytesLeft = buffer.Length;
-            int index = 0;
+            int bytesLeft = count;
+            int index = offset;
 
             while (bytesLeft > 0)
             {
-                int count = bytesLeft < BufferSize
+                int writecount = bytesLeft < BufferSize
                     ? bytesLeft
                     : BufferSize;
 
                 byte[] chunk = new byte[BufferSize];
-                Array.Copy(buffer, index, chunk, 0, count);
+                Array.Copy(buffer, index, chunk, 0, writecount);
                 chunksWritten.Add(chunk);
-                bytesLeft -= count;
-                index += count;
+                bytesLeft -= writecount;
+                index += writecount;
             }
         }
 
-        private void ThreadWorker(string value, byte[] buffer, AsyncCallback callback, AsyncResultStub ars)
+        public override void Flush(){}
+
+        private void ThreadWorker(string value, int count, byte[] buffer, AsyncCallback callback, AsyncResultStub ars)
         {
             byte[] valueBytes = UTF8Enc.GetBytes(value);
 
@@ -119,6 +125,9 @@ namespace XenConsoleComm.Tests.Stubs
             ars.BytesWritten = valueBytes.Length < BufferSize
                 ? valueBytes.Length
                 : BufferSize;
+            ars.BytesWritten = count < ars.BytesWritten
+                ? count
+                : ars.BytesWritten;
 
             Array.Copy(
                 valueBytes,
@@ -130,7 +139,7 @@ namespace XenConsoleComm.Tests.Stubs
             buffer.CopyTo(chunksRead.Last(), 0);
 
             ++_readsCompleted;
-            IsMessageComplete = (valueBytes.Length <= BufferSize);
+            _isMessageComplete = (valueBytes.Length <= BufferSize);
 
             if (InvokeCallback)
             {
@@ -143,6 +152,18 @@ namespace XenConsoleComm.Tests.Stubs
                     _callbackException = exc;
                 }
             }
+        }
+        PipeTransmissionMode _readMode;
+
+        public override PipeTransmissionMode ReadMode
+        {
+            get { return _readMode; }
+            set { _readMode = value; }
+        }
+
+        new public bool IsMessageComplete
+        {
+            get { return _isMessageComplete; }
         }
 
         public bool PipeIsClosed
@@ -157,23 +178,11 @@ namespace XenConsoleComm.Tests.Stubs
             set { _pipeIsBroken = value; }
         }
 
-        public bool CanRead
+        public override bool CanRead
         {
             get { return _canRead; }
-            set { _canRead = value; }
         }
 
-        public bool IsMessageComplete
-        {
-            get { return _isMessageComplete; }
-            set { _isMessageComplete = value; }
-        }
-
-        public bool IsConnected
-        {
-            get { return _isConnected; }
-            set { _isConnected = value; }
-        }
 
         public bool PipeServerIsReadWrite
         {

--- a/src/XenConsoleCommTests/XenConsoleMessageEventArgsTests.cs
+++ b/src/XenConsoleCommTests/XenConsoleMessageEventArgsTests.cs
@@ -2,6 +2,7 @@
 using System;
 using System.IO;
 using XenConsoleComm.Tests.Stubs;
+using XenConsoleComm.Wrappers;
 
 namespace XenConsoleComm.Tests
 {
@@ -15,7 +16,7 @@ namespace XenConsoleComm.Tests
             NamedPipeClientStreamStub pipeStream = new NamedPipeClientStreamStub();
             XenConsoleMessageEventArgs message = new XenConsoleMessageEventArgs(
                 "test",
-                pipeStream
+                new NamedPipeClientStreamWrapper(pipeStream)
             );
 
             // Assert
@@ -32,7 +33,7 @@ namespace XenConsoleComm.Tests
             NamedPipeClientStreamStub pipeStream = new NamedPipeClientStreamStub();
             XenConsoleMessageEventArgs message = new XenConsoleMessageEventArgs(
                 "test",
-                pipeStream
+                new NamedPipeClientStreamWrapper(pipeStream)
             );
 
             // Assert
@@ -56,7 +57,7 @@ namespace XenConsoleComm.Tests
 
             XenConsoleMessageEventArgs message = new XenConsoleMessageEventArgs(
                 "test",
-                pipeStream
+                new NamedPipeClientStreamWrapper(pipeStream)
             );
 
             // Assert


### PR DESCRIPTION
The console DLL thinks in terms of messages
But xencons thinks in terms of bytes

This extends the NamedPipeClientStreamWrapper to make a translation
from bytes to messages.

This also converts the NamesPipeClientStreamStub into a PipeStream
which makes it easier to test as a drop in replacement for a
NamedPipeClientStream

Finally tests are added, and fixed put in place to make testing
work better in this new world.