### PR TITLE
Correct potential out-by-one error

### DIFF
--- a/src/xenguestlib/Snapshot.cs
+++ b/src/xenguestlib/Snapshot.cs
@@ -287,7 +287,7 @@ namespace xenwinsvc
                         substr += string.Format("{0:x2}{1:x2}", ((int)backup[poscount])&0xff, (((int)backup[poscount])>>8)&0xff);
                         size--;
                         poscount++;
-                        if (((poscount % 256) == 0) || (size == 0))
+                        if (((poscount % 255) == 0) || (size == 0))
                         {
                             wmisession.GetXenStoreItem("control/snapshot/snapid/" + pagecount.ToString()).value = substr;
                             substr = "";


### PR DESCRIPTION
If the string written to xenstore is longer than 1024 characters
(including null terminator), an ASSERTion is triggered in
StoreVPrintf (ASSERT3U(Length, <=, 1024)). This will occur if any
string written to xenstore by the agent is longer than 1024 characters
including the NULL terminator.
By splitting the VSS information into chunks of up-to 256 WORDs as hex,
the resultant string is 1024 printable characters and a NULL terminator,
which will cause RtlStringCbVPrintfA to fail when given a buffer of
1024 bytes.
Change the split point for the VSS information to up-to-255 WORDs as hex,
which will produce 1020 printable characters and a NULL terminator. This
will not trigger the ASSERT

Signed-off-by: Owen Smith <owen.smith@citrix.com>