### PR TITLE
CA-270190 : Prevent left over transactions stopping transaction creation

### DIFF
--- a/src/xenguestlib/Wmi.cs
+++ b/src/xenguestlib/Wmi.cs
@@ -53,12 +53,6 @@ namespace xenwinsvc
 
         private Queue<string> debugmsg;
 
-
-
-
-
-
-
         public static bool HandleManagementException(ManagementException manex) {
             if ((manex.ErrorCode == ManagementStatus.InvalidObject) ||
                 (manex.ErrorCode == ManagementStatus.InvalidClass))
@@ -636,17 +630,77 @@ namespace xenwinsvc
         private Dictionary<string, XenStoreItem> items;
         private Dictionary<string, XenStoreItemCached> cacheditems;
 
+        public void AwaitTransactionCompletion()
+        {
+            // The plan is
+            //   1) enter the session monitor
+            //   2) once we are here, if there is a transaction, it isn't
+            //      ours, and we can kill it.
+            //   3) leave the session monitor
+            //
+            System.Threading.Monitor.Enter(session);
+            try
+            {
+                session.InvokeMethod("AbortTransaction", null);
+            }
+            catch { }
+            System.Threading.Monitor.Exit(session);
+        }
+
         public void StartTransaction()
         {
-            session.InvokeMethod("StartTransaction", null);
+            System.Threading.Monitor.Enter(session);
+            try
+            {
+                session.InvokeMethod("StartTransaction", null);
+            }
+            catch (Exception e)
+            {
+                try
+                {
+                    // We are entitled to kill any transaction running
+                    // when we have the session lock
+                    session.InvokeMethod("AbortTransaction", null);
+                    session.InvokeMethod("StartTransaction", null);
+                }
+                catch
+                {
+                    System.Threading.Monitor.Exit(session);
+                    throw e;
+                }
+            }
         }
+
         public void CommitTransaction()
         {
-            session.InvokeMethod("CommitTransaction", null);
+            try
+            {
+                session.InvokeMethod("CommitTransaction", null);
+            }
+            catch (Exception e)
+            {
+                throw e;
+            }
+            finally
+            {
+                System.Threading.Monitor.Exit(session);
+            }
         }
+
         public void AbortTransaction()
         {
-            session.InvokeMethod("AbortTransaction", null);
+            try 
+            {
+                session.InvokeMethod("AbortTransaction", null);
+            }
+            catch (Exception e)
+            {
+                throw e;
+            }
+            finally
+            {
+                System.Threading.Monitor.Exit(session);
+            }
         }
 
         public void AddWatch(string pathname) {

--- a/src/xenguestlib/Wmi.cs
+++ b/src/xenguestlib/Wmi.cs
@@ -677,10 +677,6 @@ namespace xenwinsvc
             {
                 session.InvokeMethod("CommitTransaction", null);
             }
-            catch (Exception e)
-            {
-                throw e;
-            }
             finally
             {
                 System.Threading.Monitor.Exit(session);
@@ -692,10 +688,6 @@ namespace xenwinsvc
             try 
             {
                 session.InvokeMethod("AbortTransaction", null);
-            }
-            catch (Exception e)
-            {
-                throw e;
             }
             finally
             {


### PR DESCRIPTION
Within a session, add a lock so a session cannot re-enter a transaction

When a session is not locked, any existing transaction can be killed
(it wasn't created by us, and we own the session)

When a watch event occurs, wait until the current session transaction
finishes - or break in if transaction wasn't created by us
(Otherwise we will look for the control keys whilst in the transaction
and may not find them having been set - leading us to drop the event)